### PR TITLE
Populate telemetry packet with motor errors

### DIFF
--- a/control-board/src/bin/control/control.rs
+++ b/control-board/src/bin/control/control.rs
@@ -537,6 +537,12 @@ impl<'a> Control<'a> {
         self.back_right_motor.send_motion_command();
         self.drib_motor.send_motion_command();
 
+        let err_fr = self.front_right_motor.read_is_error() as u32;
+        let err_fl = self.front_left_motor.read_is_error() as u32;
+        let err_br = self.back_right_motor.read_is_error() as u32;
+        let err_bl = self.back_left_motor.read_is_error() as u32;
+        let err_drib = self.drib_motor.read_is_error() as u32;
+
         (Some(BasicTelemetry {
             sequence_number: 0,
             robot_revision_major: 0,
@@ -545,7 +551,7 @@ impl<'a> Control<'a> {
             battery_temperature: 0.,
             _bitfield_align_1: [],
             _bitfield_1: BasicTelemetry::new_bitfield_1(
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, err_fr, 0, err_fl, 0, err_br, 0, err_bl, 0, err_drib, 0, 0, 0, 0,
             ),
             motor_0_temperature: 0.,
             motor_1_temperature: 0.,

--- a/control-board/src/bin/control/control.rs
+++ b/control-board/src/bin/control/control.rs
@@ -543,6 +543,13 @@ impl<'a> Control<'a> {
         let err_bl = self.back_left_motor.read_is_error() as u32;
         let err_drib = self.drib_motor.read_is_error() as u32;
 
+        let hall_err_fr = self.front_right_motor.check_hall_error() as u32;
+        let hall_err_fl = self.front_left_motor.check_hall_error() as u32;
+        let hall_err_br = self.back_right_motor.check_hall_error() as u32;
+        let hall_err_bl = self.back_left_motor.check_hall_error() as u32;
+        let hall_err_drib = self.drib_motor.check_hall_error() as u32;
+
+
         (Some(BasicTelemetry {
             sequence_number: 0,
             robot_revision_major: 0,
@@ -551,7 +558,7 @@ impl<'a> Control<'a> {
             battery_temperature: 0.,
             _bitfield_align_1: [],
             _bitfield_1: BasicTelemetry::new_bitfield_1(
-                0, 0, 0, 0, 0, 0, 0, 0, err_fr, 0, err_fl, 0, err_br, 0, err_bl, 0, err_drib, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, err_fr, hall_err_fr, err_fl, hall_err_fl, err_br, hall_err_br, err_bl, hall_err_bl, err_drib, hall_err_drib, 0, 0, 0,
             ),
             motor_0_temperature: 0.,
             motor_1_temperature: 0.,

--- a/control-board/src/stspin_motor.rs
+++ b/control-board/src/stspin_motor.rs
@@ -279,6 +279,10 @@ impl<
         return self.current_state.master_error() != 0;
     }
 
+    pub fn check_hall_error(&self) -> bool {
+        return self.current_state.hall_power_error() != 0 || self.current_state.hall_disconnected_error() != 0 || self.current_state.hall_enc_vel_disagreement_error() != 0;
+    }
+
     pub fn read_current(&self) -> f32 {
         return self.current_state.current_estimate;
     }
@@ -561,6 +565,10 @@ impl<
 
     pub fn read_is_error(&self) -> bool {
         return self.current_state.master_error() != 0;
+    }
+
+    pub fn check_hall_error(&self) -> bool {
+        return self.current_state.hall_power_error() != 0 || self.current_state.hall_disconnected_error() != 0 || self.current_state.hall_enc_vel_disagreement_error() != 0;
     }
 
     pub fn read_current(&self) -> f32 {


### PR DESCRIPTION
It *should* do what the title of this MR says. Someone more knowledgeable about embedded Rust than me should check.