### PR TITLE
Fix stspin init

### DIFF
--- a/motor-controller/bin/dribbler/main.c
+++ b/motor-controller/bin/dribbler/main.c
@@ -143,10 +143,10 @@ int main() {
                 // we got a motion packet!
                 ticks_since_last_command_packet = 0;
 
-                //if (motor_command_packet.data.motion.reset) {
-                //    // Block, watchdog will trigger reset.
-                //    while (true);
-                //}
+                if (motor_command_packet.data.motion.reset) {
+                    // Block, watchdog will trigger reset.
+                    while (true);
+                }
 
                 telemetry_enabled = motor_command_packet.data.motion.enable_telemetry;
                 r_motor_board = motor_command_packet.data.motion.setpoint;

--- a/motor-controller/bin/dribbler/main.c
+++ b/motor-controller/bin/dribbler/main.c
@@ -144,8 +144,8 @@ int main() {
                 ticks_since_last_command_packet = 0;
 
                 if (motor_command_packet.data.motion.reset) {
-                    // Block, watchdog will trigger reset.
-                    while (true);
+                    // Does a software reset.
+                    NVIC_SystemReset();
                 }
 
                 telemetry_enabled = motor_command_packet.data.motion.enable_telemetry;

--- a/motor-controller/bin/dribbler/main.c
+++ b/motor-controller/bin/dribbler/main.c
@@ -98,9 +98,10 @@ int main() {
     turn_off_red_led();
     turn_off_yellow_led();
 
-    // UART logging status.
-    uart_logging_status_t uart_logging_status_receive;
-    uart_logging_status_t uart_logging_status_send;
+    // Initialize UART and logging status.
+    uart_initialize();
+    uart_logging_status_rx_t uart_logging_status_receive;
+    uart_logging_status_tx_t uart_logging_status_send;
     // toggle J1-1
     while (true) {
         IWDG->KR = 0x0000AAAA; // feed the watchdog
@@ -117,11 +118,10 @@ int main() {
 
             // Read in the new packet data.
             uart_read(&motor_command_packet, sizeof(MotorCommandPacket));
-
             // If something goes wrong with the UART, we need to flag it.
-            if (uart_logging_status != UART_LOGGING_OK) {
+            if (uart_rx_get_logging_status() != UART_LOGGING_OK) {
                 // Capture the status of the UART.
-                uart_logging_status_receive = uart_logging_status;
+                uart_logging_status_receive = uart_rx_get_logging_status();
 
                 // If something went wrong, just purge all of the data.
                 uart_discard();
@@ -136,8 +136,8 @@ int main() {
                 #endif
             }
 
-            // Clear the logging for the next UART transmit / receive.
-            uart_clear_logging_status();
+            // Clear the logging for the next UART receive.
+            uart_rx_clear_logging_status();
 
             if (motor_command_packet.type == MCP_MOTION) {
                 // we got a motion packet!
@@ -235,7 +235,7 @@ int main() {
             // read error states
             const MotorErrors_t reported_motor_errors = pwm6step_get_motor_errors();
 
-            response_packet.type = MCP_MOTION;
+            response_packet.type = MRP_MOTION;
             response_packet.data.motion.master_error = false; // TODO update any error
 
             // bldc errors
@@ -279,15 +279,15 @@ int main() {
 
             // transmit packets
 #ifdef UART_ENABLED
-            // If previous UART transmit is still occurring,
-            // wait for it to finish.
-            uart_wait_for_transmission();
-            // takes ~270uS, mostly hardware DMA
-            if (run_telemetry) {
+            if (telemetry_enabled && run_telemetry) {
+                // If previous UART transmit is still occurring,
+                // wait for it to finish.
+                uart_wait_for_transmission();
+                // takes ~270uS, mostly hardware DMA, but should be cleared out by now.
                 uart_transmit((uint8_t *) &response_packet, sizeof(MotorResponsePacket));
                 // Capture the status for the response packet / LED.
-                if (uart_logging_status != UART_LOGGING_OK) {
-                    uart_logging_status_send = uart_logging_status;
+                if (uart_tx_get_logging_status() != UART_LOGGING_OK) {
+                    uart_logging_status_send = uart_tx_get_logging_status();
                 } else {
                     // If we are in COMP_MODE, don't latch the status if
                     // we are able to send a packet successfully later.
@@ -296,15 +296,15 @@ int main() {
                     #endif
                 }
 
-                // Clear the logging for the next UART transmit / receive.
-                uart_clear_logging_status();
+                // Clear the logging for the next UART transmit.
+                uart_tx_clear_logging_status();
             }
 #endif
 
             if (params_return_packet_requested) {
                 params_return_packet_requested = false;
 
-                response_packet.type = MCP_PARAMS;
+                response_packet.type = MRP_PARAMS;
 
                 response_packet.data.params.vel_p = FLT_MIN;
                 response_packet.data.params.vel_i = FLT_MIN;
@@ -319,8 +319,8 @@ int main() {
 #ifdef UART_ENABLED
                 uart_transmit((uint8_t *) &response_packet, sizeof(MotorResponsePacket));
                 // Capture the status for the response packet / LED.
-                if (uart_logging_status != UART_LOGGING_OK) {
-                    uart_logging_status_send = uart_logging_status;
+                if (uart_tx_get_logging_status() != UART_LOGGING_OK) {
+                    uart_logging_status_send = uart_tx_get_logging_status();
                 } else {
                     // If we are in COMP_MODE, don't latch the status if
                     // we are able to send a packet successfully later.
@@ -329,8 +329,8 @@ int main() {
                     #endif
                 }
 
-                // Clear the logging for the next UART transmit / receive.
-                uart_clear_logging_status();
+                // Clear the logging for the next UART transmit.
+                uart_tx_clear_logging_status();
 #endif
             }
         }

--- a/motor-controller/bin/dribbler/system.h
+++ b/motor-controller/bin/dribbler/system.h
@@ -58,4 +58,4 @@
 
 #define MOTOR_MAXIMUM_RAD_S 550.825911929f
 
-//#define COMP_MODE
+#define COMP_MODE

--- a/motor-controller/bin/wheel/main.c
+++ b/motor-controller/bin/wheel/main.c
@@ -157,9 +157,11 @@ int main() {
     turn_off_red_led();
     turn_off_yellow_led();
 
-    // UART logging status.
-    uart_logging_status_t uart_logging_status_receive;
-    uart_logging_status_t uart_logging_status_send;
+    // Initialize UART and logging status.
+    uart_initialize();
+    uart_logging_status_rx_t uart_logging_status_receive;
+    uart_logging_status_tx_t uart_logging_status_send;
+    uint16_t flash_led_counter = 0;
 
     // toggle J1-1
     while (true) {
@@ -180,9 +182,9 @@ int main() {
             uart_read(&motor_command_packet, sizeof(MotorCommandPacket));
 
             // If something goes wrong with the UART, we need to flag it.
-            if (uart_logging_status != UART_LOGGING_OK) {
+            if (uart_rx_get_logging_status() != UART_LOGGING_OK) {
                 // Capture the status of the UART.
-                uart_logging_status_receive = uart_logging_status;
+                uart_logging_status_receive = uart_rx_get_logging_status();
 
                 // If something went wrong, just purge all of the data.
                 uart_discard();
@@ -197,8 +199,8 @@ int main() {
                 #endif
             }
 
-            // Clear the logging for the next UART transmit / receive.
-            uart_clear_logging_status();
+            // Clear the logging for the next UART receive.
+            uart_rx_clear_logging_status();
 
             if (motor_command_packet.type == MCP_MOTION) {
                 // We got a motion packet!
@@ -391,7 +393,7 @@ int main() {
             // read error states
             const MotorErrors_t reported_motor_errors = pwm6step_get_motor_errors();
 
-            response_packet.type = MCP_MOTION;
+            response_packet.type = MRP_MOTION;
 
             // bldc errors
             response_packet.data.motion.hall_power_error = reported_motor_errors.hall_power;
@@ -433,15 +435,15 @@ int main() {
 
             // transmit packets
 #ifdef UART_ENABLED
-            // If previous UART transmit is still occurring,
-            // wait for it to finish.
-            uart_wait_for_transmission();
-            // takes ~270uS, mostly hardware DMA
-            if (run_telemetry) {
+            if (telemetry_enabled && run_telemetry) {
+                // If previous UART transmit is still occurring,
+                // wait for it to finish.
+                uart_wait_for_transmission();
+                // takes ~270uS, mostly hardware DMA, but should be cleared out by now.
                 uart_transmit((uint8_t *) &response_packet, sizeof(MotorResponsePacket));
                 // Capture the status for the response packet / LED.
-                if (uart_logging_status != UART_LOGGING_OK) {
-                    uart_logging_status_send = uart_logging_status;
+                if (uart_tx_get_logging_status() != UART_LOGGING_OK) {
+                    uart_logging_status_send = uart_tx_get_logging_status();
                 } else {
                     // If we are in COMP_MODE, don't latch the status if
                     // we are able to send a packet successfully later.
@@ -451,14 +453,14 @@ int main() {
                 }
 
                 // Clear the logging for the next UART transmit / receive.
-                uart_clear_logging_status();
+                uart_tx_clear_logging_status();
             }
 #endif
 
             if (params_return_packet_requested) {
                 params_return_packet_requested = false;
 
-                response_packet.type = MCP_PARAMS;
+                response_packet.type = MRP_PARAMS;
 
                 response_packet.data.params.version_major = VERSION_MAJOR;
                 response_packet.data.params.version_major = VERSION_MINOR;
@@ -478,8 +480,8 @@ int main() {
 #ifdef UART_ENABLED
                 uart_transmit((uint8_t *) &response_packet, sizeof(MotorResponsePacket));
                 // Capture the status for the response packet / LED.
-                if (uart_logging_status != UART_LOGGING_OK) {
-                    uart_logging_status_send = uart_logging_status;
+                if (uart_tx_get_logging_status() != UART_LOGGING_OK) {
+                    uart_logging_status_send = uart_tx_get_logging_status();
                 } else {
                     // If we are in COMP_MODE, don't latch the status if
                     // we are able to send a packet successfully later.
@@ -489,7 +491,7 @@ int main() {
                 }
 
                 // Clear the logging for the next UART transmit / receive.
-                uart_clear_logging_status();
+                uart_tx_clear_logging_status();
 #endif
             }
         }
@@ -504,10 +506,23 @@ int main() {
 
         // Red LED means we are in an error state.
         // This latches and requires resetting the robot to clear.
+        #ifdef COMP_MODE
         if (response_packet.data.motion.master_error ||
             (telemetry_enabled && ticks_since_last_command_packet > COMMAND_PACKET_TIMEOUT_TICKS)) {
             turn_on_red_led();
         }
+        #else
+        if (run_telemetry) {
+            flash_led_counter += 1;
+            if (flash_led_counter > 200) {
+                flash_led_counter = 0;
+                turn_off_red_led();
+            }
+            else if (flash_led_counter > 100) {
+                turn_on_red_led();
+            }
+        }
+        #endif
 
         // Yellow LED means we are in an warning state.
         // Will clear if resolved.

--- a/motor-controller/bin/wheel/main.c
+++ b/motor-controller/bin/wheel/main.c
@@ -206,8 +206,8 @@ int main() {
                 ticks_since_last_command_packet = 0;
 
                 if (motor_command_packet.data.motion.reset) {
-                    // Block, watchdog will trigger reset.
-                    while (true);
+                    // Does a software reset.
+                    NVIC_SystemReset();
                 }
 
                 telemetry_enabled = motor_command_packet.data.motion.enable_telemetry;

--- a/motor-controller/bin/wheel/main.c
+++ b/motor-controller/bin/wheel/main.c
@@ -161,7 +161,6 @@ int main() {
     uart_initialize();
     uart_logging_status_rx_t uart_logging_status_receive;
     uart_logging_status_tx_t uart_logging_status_send;
-    uint16_t flash_led_counter = 0;
 
     // toggle J1-1
     while (true) {
@@ -206,11 +205,10 @@ int main() {
                 // We got a motion packet!
                 ticks_since_last_command_packet = 0;
 
-                //if (motor_command_packet.data.motion.reset) {
-                //    // Block, watchdog will trigger reset.
-                //
-                //    while (true);
-                //}
+                if (motor_command_packet.data.motion.reset) {
+                    // Block, watchdog will trigger reset.
+                    while (true);
+                }
 
                 telemetry_enabled = motor_command_packet.data.motion.enable_telemetry;
                 r_motor_board = motor_command_packet.data.motion.setpoint;
@@ -506,23 +504,10 @@ int main() {
 
         // Red LED means we are in an error state.
         // This latches and requires resetting the robot to clear.
-        #ifdef COMP_MODE
         if (response_packet.data.motion.master_error ||
             (telemetry_enabled && ticks_since_last_command_packet > COMMAND_PACKET_TIMEOUT_TICKS)) {
             turn_on_red_led();
         }
-        #else
-        if (run_telemetry) {
-            flash_led_counter += 1;
-            if (flash_led_counter > 200) {
-                flash_led_counter = 0;
-                turn_off_red_led();
-            }
-            else if (flash_led_counter > 100) {
-                turn_on_red_led();
-            }
-        }
-        #endif
 
         // Yellow LED means we are in an warning state.
         // Will clear if resolved.

--- a/motor-controller/bin/wheel/system.h
+++ b/motor-controller/bin/wheel/system.h
@@ -49,4 +49,4 @@
 
 // #define MOTOR_MAXIMUM_RAD_S 550.825911929f
 
-//#define COMP_MODE
+#define COMP_MODE

--- a/motor-controller/common/debug.c
+++ b/motor-controller/common/debug.c
@@ -29,20 +29,20 @@ void turn_off_green_led() {
 
 void _debug_value_manchester_8(uint8_t val) {
     turn_off_yellow_led();
-    wait_ms(1);
+    wait_cyc(50);
 
     for (int i = 8; i >= 0; i--) {
         turn_on_yellow_led();
-        wait_ms(1);
+        wait_cyc(50);
         if (((val >> i) & 0x1) != 0) {
-            wait_ms(1);
+            wait_cyc(50);
             turn_off_yellow_led();
         } else {
             turn_off_yellow_led();
-            wait_ms(1);
+            wait_cyc(50);
         }
 
-        wait_ms(1);
+        wait_cyc(50);
     }
 }
 

--- a/motor-controller/common/time.c
+++ b/motor-controller/common/time.c
@@ -4,9 +4,9 @@
  * @brief defines all functions related to time keeping
  * @version 0.1
  * @date 2022-04-19
- * 
+ *
  * @copyright Copyright (c) 2022
- * 
+ *
  */
 
 #include <stdbool.h>
@@ -18,7 +18,7 @@
 
 /**
  * @brief blocks for a number of milliseconds
- * 
+ *
  */
 __attribute__((optimize("O0")))
 void wait_ms(uint32_t time_ms) {
@@ -31,7 +31,7 @@ void wait_ms(uint32_t time_ms) {
 
 /**
  * @brief blocks until SysTick fires
- * 
+ *
  * @return true if the tick has already elapsed and no waiting occurred
  *          can be used to determine if a core process is not meeting timing slack requirements
  */
@@ -69,10 +69,10 @@ uint32_t time_local_epoch_s() {
 }
 
 /**
- * @brief 
- * 
- * @param time_sync 
- * @param ticks 
+ * @brief
+ *
+ * @param time_sync
+ * @param ticks
  */
 void time_sync_init(SyncTimer_t *time_sync, uint32_t ticks) {
     time_sync->sync_time_ticks = ticks;
@@ -110,4 +110,8 @@ bool time_sync_block_rst(SyncTimer_t *time_sync) {
     return res;
 }
 
-
+void wait_cyc(uint32_t cycles) {
+    for (uint32_t count = 0; count < cycles; count++) {
+        asm volatile("nop");
+    }
+}

--- a/motor-controller/common/uart.h
+++ b/motor-controller/common/uart.h
@@ -11,18 +11,22 @@
 
 #pragma once
 
+#define UART_LOGGING_OK 0
+
 typedef enum {
-    UART_LOGGING_OK = 0,
-    UART_LOGGING_DMA_TX_ERROR = 1,
-    UART_LOGGING_DMA_RX_ERROR = 2,
-    UART_LOGGING_DMA_RX_BUFFER_FULL = 3,
-    UART_LOGGING_UART_RX_BUFFER_FULL = 4,
-    UART_LOGGING_UART_RX_PARITY_ERROR = 5,
-    UART_LOGGING_UART_RX_BUFFER_EMPTY = 6,
-    UART_LOGGING_UART_RX_SIZE_MISMATCH = 7,
-    UART_LOGGING_UART_TX_BUFFER_FULL = 8,
-    UART_LOGGING_UART_TX_SIZE_MISMATCH = 9
-} uart_logging_status_t;
+    UART_LOGGING_DMA_TX_ERROR = 1 << 0,
+    UART_LOGGING_UART_TX_BUFFER_FULL = 1 << 1,
+    UART_LOGGING_UART_TX_SIZE_MISMATCH = 1 << 2
+} uart_logging_status_tx_t;
+
+typedef enum {
+    UART_LOGGING_DMA_RX_ERROR = 1 << 0,
+    UART_LOGGING_DMA_RX_BUFFER_FULL = 1 << 1,
+    UART_LOGGING_UART_RX_BUFFER_FULL = 1 << 2,
+    UART_LOGGING_UART_RX_PARITY_ERROR = 1 << 3,
+    UART_LOGGING_UART_RX_BUFFER_EMPTY = 1 << 4,
+    UART_LOGGING_UART_RX_SIZE_MISMATCH = 1 << 5,
+} uart_logging_status_rx_t;
 
 ////////////////////////
 //  PUBLIC FUNCTIONS  //
@@ -37,5 +41,8 @@ bool uart_can_read();
 void uart_discard();
 void uart_read(void *dest, uint16_t len);
 
-static volatile uart_logging_status_t uart_logging_status;
-void uart_clear_logging_status();
+void uart_tx_clear_logging_status();
+uart_logging_status_tx_t uart_tx_get_logging_status();
+
+void uart_rx_clear_logging_status();
+uart_logging_status_rx_t uart_rx_get_logging_status();


### PR DESCRIPTION
This pull request includes several changes to the `motor-controller` codebase, focusing on improving the UART logging system and optimizing the timing functions. The most important changes include the introduction of separate logging statuses for UART transmission and reception, the addition of a new timing function, and various improvements to the UART initialization and handling.

### UART Logging Improvements:
* Split the `uart_logging_status` into two separate enums: `uart_logging_status_tx_t` for transmission and `uart_logging_status_rx_t` for reception, and updated the relevant functions to use these new types. [[1]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L130-R162) [[2]](diffhunk://#diff-083ed7415cea72d31a74b759c7e0526ae7173c3ede44a6d2128240a855edb731R14-R29) [[3]](diffhunk://#diff-083ed7415cea72d31a74b759c7e0526ae7173c3ede44a6d2128240a855edb731L40-R48)
* Updated the UART logging functions to handle the new logging statuses, including `uart_tx_clear_logging_status`, `uart_tx_get_logging_status`, `uart_rx_clear_logging_status`, and `uart_rx_get_logging_status`. [[1]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L130-R162) [[2]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L182-R207) [[3]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L216-L225)

### Timing Function Optimization:
* Replaced the `wait_ms` function calls with a new `wait_cyc` function to improve timing precision by using CPU cycles instead of milliseconds. [[1]](diffhunk://#diff-2e56aa23dfe96b9b64db6cb80dba6c8607f8f0724e2ef761ce41fa8e895faa6bL32-R45) [[2]](diffhunk://#diff-1cd47da10763aec85f3bdfe4a4d9b10f5700865ba1e4bbf3eb0c8a42d57a7029L113-R117)

### UART Initialization and Handling:
* Added a new `init_run` flag to ensure proper initialization before UART operations, and updated the relevant functions to check this flag. [[1]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1R29-R32) [[2]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1R55-R56) [[3]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L63-R78) [[4]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L113-R120)

### Minor Fixes:
* Corrected the usage of bitwise OR assignment (`|=`) for clearing and setting flags in the UART DMA handling functions. [[1]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L96-R105) [[2]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L216-L225) [[3]](diffhunk://#diff-5aba0447bf9a608cdbb94151b3500446897d37df9dacfba95d72b4995a6137d1L246-R279)