### PR TITLE
Smart Wheel Firmware Flashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,16 +141,16 @@ define create-control-board-rust-targets
 $1--$2: kicker-board--all motor-controller--all
 	cd $1 && \
 	cargo build $(additional_control_cargo_flags) --release --bin $2 && \
-	arm-none-eabi-objcopy -O binary target/thumbv7em-none-eabihf/release/$2 target/thumbv7em-none-eabihf/release/$2.bin
+	arm-none-eabi-objcopy -O binary target/thumbv7em-none-eabihf/release/$2 target/thumbv7em-none-eabihf/release/$2.bin && \
+	python ../util/embed_wheel_img_hash.py
 control-board--all:: $1--$2
 
-$1--$2--run: kicker-board--all motor-controller--all
+$1--$2--run: $1--$2
 	cd $1 && \
 	cargo run $(additional_control_cargo_flags) --release --bin $2
 
-$1--$2--debug: kicker-board--all motor-controller--all
+$1--$2--debug: $1--$2
 	cd $1 && \
-	cargo build $(additional_control_cargo_flags) --release --bin $2 && \
 	../util/program.sh $3 target/thumbv7em-none-eabihf/release/$2
 endef
 $(foreach element,$(control_binaries),$(eval $(call create-control-board-rust-targets,control-board,$(element),$(control_openocd_cfg_file))))

--- a/control-board/src/image_hash.rs
+++ b/control-board/src/image_hash.rs
@@ -1,0 +1,17 @@
+use core::ptr::read_volatile;
+
+struct WheelImgHash {
+    wheel_img_hash_magic: [u8; 16],
+    wheel_img_hash: [u8; 16]
+}
+static mut WHEEL_IMG_HASH: WheelImgHash = WheelImgHash {
+    wheel_img_hash_magic: *b"WheelImgHashCtrl",
+    wheel_img_hash: [0; 16]
+};
+
+pub fn get_wheel_img_hash() -> [u8; 16] {
+    // Enforce a read from memory because the hash is injected at build time
+    unsafe {
+        return read_volatile(&WHEEL_IMG_HASH.wheel_img_hash as *const [u8; 16]);
+    }
+}

--- a/control-board/src/lib.rs
+++ b/control-board/src/lib.rs
@@ -32,6 +32,7 @@ pub mod pins;
 pub mod robot_state;
 pub mod songs;
 pub mod stspin_motor;
+pub mod image_hash;
 
 pub mod drivers;
 pub mod motion;

--- a/control-board/src/stspin_motor.rs
+++ b/control-board/src/stspin_motor.rs
@@ -188,7 +188,7 @@ impl<
 
                 // copy receieved uart bytes into packet
                 let state = &mut mrp as *mut _ as *mut u8;
-                for i in 0..core::mem::size_of::<MotorResponse_Motion_Packet>() {
+                for i in 0..core::mem::size_of::<MotorResponsePacket>() {
                     *state.offset(i as isize) = buf[i];
                 }
 

--- a/control-board/src/stspin_motor.rs
+++ b/control-board/src/stspin_motor.rs
@@ -6,18 +6,20 @@ use embassy_stm32::{
     gpio::{Pin, Pull},
     usart::{self, Parity},
 };
-use embassy_time::{Duration, Timer};
+use embassy_time::{with_timeout, Duration, Timer};
 use nalgebra::Vector3;
 
 use ateam_common_packets::bindings::{
     MotorCommandPacket,
     MotorCommandPacketType::MCP_MOTION,
+    MotorCommandPacketType::MCP_PARAMS,
     MotorCommand_MotionType,
     MotorCommand_MotionType::OPEN_LOOP,
     MotorResponsePacket,
     MotorResponsePacketType::{MRP_MOTION, MRP_PARAMS},
     MotorResponse_Motion_Packet, MotorResponse_Params_Packet,
 };
+use crate::image_hash;
 
 pub struct WheelMotor<
     'a,
@@ -152,11 +154,63 @@ impl<
         self.stm32_uart_interface.leave_reset().await;
     }
 
+    pub async fn check_wheel_needs_flash(&mut self) -> bool {
+        let mut wheel_needs_flash = true;
+        let wheel_img_hash_ctrl: [u8; 16] = image_hash::get_wheel_img_hash();
+        defmt::debug!("Wheel Image Hash from Control Board - {:x}", wheel_img_hash_ctrl);
+
+        defmt::trace!("Drive Motor - Update UART config 2 MHz");
+        self.stm32_uart_interface.update_uart_config(2_000_000, Parity::ParityEven).await;
+        Timer::after(Duration::from_millis(1)).await;
+
+        let wheel_img_hash_future = async {
+            loop {
+                defmt::trace!("Drive Motor - sending parameter command packet");
+                self.send_params_command();
+
+                Timer::after(Duration::from_millis(100)).await;
+
+                defmt::trace!("Drive Motor - Checking for parameter response");
+                // Parse incoming packets
+                self.process_packets();
+                // Check if curret_params_state has updated
+                if self.current_params_state.wheel_img_hash != [0; 4] {
+                    let wheel_img_hash_motr = self.current_params_state.wheel_img_hash;
+                    defmt::debug!("Drive Motor - Received parameter response");
+                    defmt::debug!("Wheel Image Hash from Motor - {:x}", wheel_img_hash_motr);
+                    return wheel_img_hash_motr
+                };
+            }
+        };
+        let wheel_response_timeout = Duration::from_millis(1000);
+    
+        defmt::trace!("Drive Motor - waiting for parameter response packet");
+        match with_timeout(wheel_response_timeout, wheel_img_hash_future).await {
+            Ok(wheel_img_hash_motr) => {
+                if wheel_img_hash_motr == wheel_img_hash_ctrl[..4] {
+                    wheel_needs_flash = false;
+                }
+            },
+            Err(_) => {
+                defmt::trace!("Drive Motor - No parameter response, motor controller needs flashing");
+                wheel_needs_flash = true;
+            },
+        }
+        return wheel_needs_flash;
+    }
+
     pub async fn load_firmware_image(&mut self, fw_image_bytes: &[u8]) -> Result<(), ()> {
-        let res = self
-            .stm32_uart_interface
-            .load_firmware_image(fw_image_bytes)
-            .await;
+        let controller_needs_flash: bool = self.check_wheel_needs_flash().await;
+        defmt::debug!("Motor Controller Needs Flash - {:?}", controller_needs_flash);
+
+        let res;
+        if controller_needs_flash {
+            defmt::trace!("UART config updated");
+            res = self.stm32_uart_interface.load_firmware_image(fw_image_bytes).await;
+        } else {
+            defmt::info!("Wheel image is up to date, skipping flash");
+            res = Ok(());
+        }
 
         // this is safe because load firmware image call will reset the target device
         // it will begin issueing telemetry updates
@@ -223,6 +277,8 @@ impl<
                     // info!("reset_low_power {:?}", mrp.data.motion.reset_low_power());
                     // info!("reset_software {:?}", mrp.data.motion.reset_software());
                 } else if mrp.type_ == MRP_PARAMS {
+                    trace!("Received parameter response packet");
+                    debug!("Parameter response data: {:?}", buf);
                     self.current_params_state = mrp.data.params;
                 }
             }
@@ -244,6 +300,27 @@ impl<
         }
         if self.current_state.reset_pin() != 0 {
             defmt::warn!("Drive Motor {} Reset: Pin", motor_id);
+        }
+    }
+
+    pub fn send_params_command(&mut self) {
+        unsafe {
+            let mut cmd: MotorCommandPacket = { MaybeUninit::zeroed().assume_init() };
+
+            cmd.type_ = MCP_PARAMS;
+            cmd.crc32 = 0;
+
+            // TODO figure out what to set here
+            // Update a param like this
+            // cmd.data.params.set_update_timestamp(1);
+            // cmd.data.params.timestamp = 0x0;
+
+            let struct_bytes = core::slice::from_raw_parts(
+                (&cmd as *const MotorCommandPacket) as *const u8,
+                core::mem::size_of::<MotorCommandPacket>(),
+            );
+
+            self.stm32_uart_interface.send_or_discard_data(struct_bytes);
         }
     }
 

--- a/motor-controller/bin/wheel/main.c
+++ b/motor-controller/bin/wheel/main.c
@@ -30,6 +30,7 @@
 #include "system.h"
 #include "time.h"
 #include "uart.h"
+#include "image_hash.h"
 
 static int slipped_control_frame_count = 0;
 
@@ -476,6 +477,7 @@ int main() {
                 response_packet.data.params.torque_i_max = torque_pid_constants.kI_max;
                 response_packet.data.params.cur_clamp = (uint16_t) cur_limit;
 
+                memcpy(response_packet.data.params.wheel_img_hash, get_wheel_img_hash(), sizeof(response_packet.data.params.wheel_img_hash));
 #ifdef UART_ENABLED
                 uart_transmit((uint8_t *) &response_packet, sizeof(MotorResponsePacket));
                 // Capture the status for the response packet / LED.

--- a/motor-controller/bin/wheel/main.c
+++ b/motor-controller/bin/wheel/main.c
@@ -462,8 +462,8 @@ int main() {
                 response_packet.type = MRP_PARAMS;
 
                 response_packet.data.params.version_major = VERSION_MAJOR;
-                response_packet.data.params.version_major = VERSION_MINOR;
-                response_packet.data.params.version_major = VERSION_PATCH;
+                response_packet.data.params.version_minor = VERSION_MINOR;
+                response_packet.data.params.version_patch = VERSION_PATCH;
                 response_packet.data.params.timestamp = time_local_epoch_s();
 
                 response_packet.data.params.vel_p = vel_pid_constants.kP;

--- a/motor-controller/common/image_hash.c
+++ b/motor-controller/common/image_hash.c
@@ -1,0 +1,22 @@
+/**
+ * @file image_hash.c
+ * @author Nicholas Witten
+ * @brief Struct instantiation to hold embeddable git information
+ * @version 0.1
+ * @date 2022-05-22
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ */
+
+#include "image_hash.h"
+
+
+static volatile WheelImgHash_t wheel_img_hash_struct = {
+    "WheelImgHashMotr",
+    {0},
+};  // Motor bin hash will be injected upon build
+
+const char* get_wheel_img_hash(void) {
+    return wheel_img_hash_struct.wheel_img_hash;
+}

--- a/motor-controller/common/image_hash.h
+++ b/motor-controller/common/image_hash.h
@@ -1,0 +1,19 @@
+/**
+ * @file image_hash.h
+ * @author Nicholas Witten
+ * @brief 
+ * @version 0.1
+ * @date 2025-01-18
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ */
+#pragma once
+#include <stdint.h>
+
+typedef struct WheelImgHash {
+    char wheel_img_hash_magic[16];
+    char wheel_img_hash[16];
+} WheelImgHash_t;
+
+const char* get_wheel_img_hash(void);

--- a/util/embed_wheel_img_hash.py
+++ b/util/embed_wheel_img_hash.py
@@ -1,0 +1,75 @@
+"""
+Author: Nicholas Witten
+Data: 01/18/2025
+
+Embeds the wheel image hash into both the control board and wheel firmware
+binaries. Since the wheel firmware binary is included inside the control board
+binary, this can be done by searching through and modifying only the control
+board image. The hash of the wheel image changes after inserting the hash value
+itself, so the value of the pre-inserted image hash (the value is zeroed out) is
+used on both the control board and wheel sides.
+"""
+import os
+import subprocess
+import binascii
+import traceback
+
+
+firmware_dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+control_bin_path = os.path.join(firmware_dir_path, "control-board/target/thumbv7em-none-eabihf/release/control")
+wheel_img_path = os.path.join(firmware_dir_path, "motor-controller/build/bin/wheel.bin")
+wheel_img_hash_magic_control_board = b'WheelImgHashCtrl'
+wheel_img_hash_magic_motor_controller = b'WheelImgHashMotr'
+assert len(wheel_img_hash_magic_control_board) == len(wheel_img_hash_magic_motor_controller)
+img_hash_offset = len(wheel_img_hash_magic_control_board)  # Bytes into WheelImgHash struct
+img_hash_length = 16
+
+
+def get_img_hash(fpath):
+    p = subprocess.run(["md5sum", fpath], text=True, stdout=subprocess.PIPE)
+    if p.returncode != 0:
+        raise Exception(f"Unable to get hash, command failed: md5sum {fpath}")
+    hash_string = p.stdout.split(" ")[0]
+    return binascii.unhexlify(hash_string)  # turn into bytes object
+
+def embed_img_hash(fpath, img_hash_magic, img_hash):
+    with open(fpath, "rb") as f:
+        image = f.read()
+
+    # Find the firmware hash struct in the image
+    struct_start_idx = image.find(img_hash_magic)  # It'll be backwards because of little endian byte
+    if struct_start_idx == -1:
+        raise Exception(f"Unable to find firmware hash magic bytes in {fpath}")
+    # is it possible this sequence happens to occur more than once?
+    if image.find(img_hash_magic[:], struct_start_idx+1) != -1:
+        raise Exception("Unable to determine firmware hash structure location, magic bytes occur more than once")
+
+    # Construct the new image with an edited firmware hash struct
+    new_image = bytearray(image)
+    new_image[struct_start_idx+img_hash_offset:struct_start_idx+img_hash_offset+img_hash_length] = img_hash
+
+    # Write the new image replacing the old one
+    with open(fpath, "wb") as f:
+        f.write(new_image)
+
+def try_embed_wheel_img_hash(fpath):
+    try:
+        if not os.path.exists(fpath):
+            raise Exception(f"path not found - {fpath}")
+        if not os.path.exists(wheel_img_path):
+            raise Exception(f"path not found - {wheel_img_path}")
+        img_hash = get_img_hash(wheel_img_path)
+        embed_img_hash(fpath, wheel_img_hash_magic_control_board, img_hash)
+        embed_img_hash(fpath, wheel_img_hash_magic_motor_controller, img_hash)
+        print(f"embed_git_status.py - SUCCESS - Embedded motor img hash into {fpath}")
+    except:
+        print(f"embed_git_status.py - WARNING - Unable to embed the firmware hash in {fpath}")
+        print(traceback.format_exc())
+
+
+if __name__ == "__main__":
+    img_path = os.path.join(firmware_dir_path, f"control-board/target/thumbv7em-none-eabihf/release/control")
+    try_embed_wheel_img_hash(img_path)
+    # Do we use control.bin for anything?
+    img_path = img_path + ".bin"
+    try_embed_wheel_img_hash(img_path)


### PR DESCRIPTION
Only flash motor controllers when needed

At Build Time:
- take the MD5 hash of the wheel binary image
- Search the control binary for the two WheelImgHash structures by finding the magic string which is the first member of the struct. One is for use by the H7 and the other is inside the included wheel firmware binary.
- Insert the hash value into both of the structures. This changes the hash value of the wheel binary if it were computed again. That’s why we use the hash of the pre-modified image with the hash value zeroed out.

At H7 MCU startup
- Send a parameter command to each wheel motor controller
- Wait 1s for a param response, retrying every 100 ms
- Param response will have the hash of the currently running firmware, or not at all (before this update)
- If this hash matches the hash that was embedded on the H7 side, the flash is skipped
- In all other cases the wheel controller is reflashed