### PR TITLE
Removes reference to old alias nixpkgs.nixFlakes

### DIFF
--- a/util/setup.bash
+++ b/util/setup.bash
@@ -64,8 +64,6 @@ if ! command -v nix > /dev/null; then
 	fi
 fi
 
-nix-env -iA nixpkgs.nixFlakes
-
 # check for or create a Nix config file
 if [ ! -f ~/.config/nix/nix.conf ]; then
 	echo "Creaing nix config file..."


### PR DESCRIPTION
The removed line was failing because the `nixFlakes` alias has been removed as of October, 2024.
Running this script with this line removed seems to have successfully setup my laptop for firmware for the first time.