### PR TITLE
DIP To Disable Extended Telemetry

### DIFF
--- a/control-board/src/robot_state.rs
+++ b/control-board/src/robot_state.rs
@@ -21,6 +21,7 @@ pub struct SharedRobotState {
     last_packet_receive_time_ticks_ms: AtomicU32,
     radio_network_ok: AtomicBool,
     radio_bridge_ok: AtomicBool,
+    radio_send_extended_telem: AtomicBool,
 
 
     battery_low: AtomicBool,
@@ -50,7 +51,8 @@ impl SharedRobotState {
             dribbler_inop: AtomicBool::new(true),
             last_packet_receive_time_ticks_ms: AtomicU32::new(0),
             radio_network_ok: AtomicBool::new(false), 
-            radio_bridge_ok: AtomicBool::new(false), 
+            radio_bridge_ok: AtomicBool::new(false),
+            radio_send_extended_telem: AtomicBool::new(false),
             battery_low: AtomicBool::new(false),
             battery_crit: AtomicBool::new(false),
             robot_tipped: AtomicBool::new(false),
@@ -78,6 +80,7 @@ impl SharedRobotState {
             last_packet_receive_time_ticks_ms: 0,
             radio_network_ok: self.get_radio_network_ok(),
             radio_bridge_ok: self.get_radio_bridge_ok(),
+            radio_send_extended_telem: self.get_radio_send_extended_telem(),
 
             battery_low: self.get_battery_low(),
             battery_crit: self.get_battery_crit(),
@@ -226,6 +229,14 @@ impl SharedRobotState {
         self.radio_bridge_ok.store(bridge_ok, Ordering::Relaxed);
     }
 
+    pub fn get_radio_send_extended_telem(&self) -> bool {
+        self.radio_send_extended_telem.load(Ordering::SeqCst)
+    }
+
+    pub fn set_radio_send_extended_telem(&self, send_extended_telem: bool) {
+        self.radio_send_extended_telem.store(send_extended_telem, Ordering::SeqCst);
+    }
+
     pub fn ball_detected(&self) -> bool {
         self.ball_detected.load(Ordering::Relaxed)
     }
@@ -262,6 +273,7 @@ pub struct RobotState {
     pub last_packet_receive_time_ticks_ms: u32,
     pub radio_network_ok: bool,
     pub radio_bridge_ok: bool,
+    pub radio_send_extended_telem: bool,
 
     pub battery_low: bool,
     pub battery_crit: bool,

--- a/control-board/src/tasks/radio_task.rs
+++ b/control-board/src/tasks/radio_task.rs
@@ -373,8 +373,10 @@ impl<
                         self.last_basic_telemetry = basic;
                     },
                     TelemetryPacket::Extended(control) => {
-                        if self.radio.send_control_debug_telemetry(control).await.is_err() {
-                            defmt::warn!("RadioTask - failed to send control debug telemetry packet");
+                        if self.shared_robot_state.get_radio_send_extended_telem() {
+                            if self.radio.send_control_debug_telemetry(control).await.is_err() {
+                                defmt::warn!("RadioTask - failed to send control debug telemetry packet");
+                            }
                         }
                     },
                     TelemetryPacket::ParameterCommandResponse(pc_resp) => {

--- a/control-board/src/tasks/user_io_task.rs
+++ b/control-board/src/tasks/user_io_task.rs
@@ -79,6 +79,7 @@ async fn user_io_task_entry(
 
         // read switches
         let robot_network_index = dip_switch.read_block(7..4);
+        let send_extended_telem = dip_switch.read_pin(0);
         let hw_debug_mode = debug_mode_dip_switch.read_pin(0);
         let robot_team_isblue = robot_color_dip_switch.read_pin(1);
         let robot_id = robot_id_rotary.read_value();
@@ -104,6 +105,11 @@ async fn user_io_task_entry(
         if robot_network_index != cur_robot_state.hw_wifi_network_index as u8 {
             robot_state.set_hw_network_index(robot_network_index);
             defmt::info!("updated robot network index {} -> {}", cur_robot_state.hw_wifi_network_index, robot_network_index);
+        }
+
+        if send_extended_telem != cur_robot_state.radio_send_extended_telem {
+            robot_state.set_radio_send_extended_telem(send_extended_telem);
+            defmt::info!("updated robot send extended telem {} -> {}", cur_robot_state.radio_send_extended_telem, send_extended_telem);
         }
     
         ///////////////////////
@@ -149,7 +155,12 @@ async fn user_io_task_entry(
             debug_led0.set_high();
         }
 
-        debug_led1.set_low();
+        if send_extended_telem {
+            debug_led1.set_high();
+        } else {
+            debug_led1.set_low();
+        }
+
         debug_led2.set_low();
 
         if hw_debug_mode {


### PR DESCRIPTION
This may be a precursor to a fully implemented #80, but this is intended to be a quick and dirty way to just substantially lower the load on the radio in a pinch.