### PR TITLE
bugfix blocking on repeated song request enqueue during shutdown

### DIFF
--- a/power-board/src/bin/power/main.rs
+++ b/power-board/src/bin/power/main.rs
@@ -97,9 +97,9 @@ async fn main(spawner: Spawner) {
         // read pwr button
         // shortest possible interrupt from pwr btn controller is 32ms
         if pwr_btn.get_level() == Level::Low || SHARED_POWER_STATE.get_shutdown_requested().await {
-            main_audio_publisher
-                .publish(AudioCommand::PlaySong(SongId::ShutdownRequested))
-                .await;
+            let _ =
+                main_audio_publisher.try_publish(AudioCommand::PlaySong(SongId::ShutdownRequested));
+            let mut last_shutdown_song_time = Instant::now();
             Timer::after_millis(250).await;
             shutdown_ind.set_low(); // indicate shutdown request
             let shutdown_requested_time = Instant::now();
@@ -117,9 +117,8 @@ async fn main(spawner: Spawner) {
                     || Instant::now() > shutdown_requested_time + Duration::from_secs(30)
                     || !cur_robot_state.coms_established
                 {
-                    main_audio_publisher
-                        .publish(AudioCommand::PlaySong(SongId::PowerOff))
-                        .await;
+                    let _ =
+                        main_audio_publisher.try_publish(AudioCommand::PlaySong(SongId::PowerOff));
                     // Wait long enough for the song to play :)
                     Timer::after_millis(500).await;
                     defmt::info!("MAIN TASK: Shutdown acknowledged, turning off power");
@@ -127,6 +126,12 @@ async fn main(spawner: Spawner) {
                     sequence_power_off(&mut en_3v3, &mut en_5v0, &mut en_12v0).await;
                     kill_sig.set_low();
                     break;
+                }
+
+                if last_shutdown_song_time.elapsed() >= Duration::from_millis(2000) {
+                    let _ = main_audio_publisher
+                        .try_publish(AudioCommand::PlaySong(SongId::ShutdownRequested));
+                    last_shutdown_song_time = Instant::now();
                 }
 
                 Timer::after_millis(10).await;

--- a/power-board/src/tasks/coms_task.rs
+++ b/power-board/src/tasks/coms_task.rs
@@ -8,7 +8,6 @@ use embassy_stm32::{
 use crate::{pins::*, power_state::SharedPowerState, SystemIrqs, DEBUG_UART_QUEUES};
 use ateam_common_packets::bindings::{BatteryInfo, PowerCommand, PowerTelemetry};
 use ateam_lib_stm32::{
-    audio::{songs::SongId, AudioCommand},
     idle_buffered_uart_spawn_tasks, static_idle_buffered_uart_nl,
     uart::queue::{IdleBufferedUart, UartReadQueue, UartWriteQueue},
 };
@@ -63,7 +62,7 @@ async fn coms_task_entry(
     write_queue: &'static UartWriteQueue<MAX_TX_PACKET_SIZE, TX_BUF_DEPTH, DEBUG_UART_QUEUES>,
     shared_power_state: &'static SharedPowerState,
     mut telemetry_subscriber: TelemetrySubscriber,
-    audio_publisher: AudioPublisher,
+    _audio_publisher: AudioPublisher,
 ) {
     let mut loop_rate_ticker = Ticker::every(Duration::from_millis(10));
     let mut last_battery_telem_packet: BatteryInfo = Default::default();
@@ -121,9 +120,6 @@ async fn coms_task_entry(
 
             if command_packet.request_shutdown() != 0 {
                 defmt::info!("COMS TASK - request shutdown received from control board");
-                audio_publisher
-                    .publish(AudioCommand::PlaySong(SongId::ShutdownRequested))
-                    .await;
                 shared_power_state.set_shutdown_requested(true).await;
             }
 
@@ -193,7 +189,7 @@ pub async fn start_coms_task(
     uart_queue_spawner: SendSpawner,
     shared_power_state: &'static SharedPowerState,
     telemetry_subscriber: TelemetrySubscriber,
-    audio_publisher: AudioPublisher,
+    _audio_publisher: AudioPublisher,
     uart: Peri<'static, ComsUart>,
     uart_rx_pin: Peri<'static, ComsUartRxPin>,
     uart_tx_pin: Peri<'static, ComsUartTxPin>,
@@ -220,7 +216,7 @@ pub async fn start_coms_task(
             &COMS_IDLE_BUFFERED_UART.get_uart_write_queue(),
             shared_power_state,
             telemetry_subscriber,
-            audio_publisher,
+            _audio_publisher,
         ))
         .expect("failed to spawn coms task");
 }


### PR DESCRIPTION
Song request enqueue was blocking main loop for power board as the shutdown song was repeatedly enqueued and only dequeued after each song was completed.

Removed redundant request in the coms task.

Changed spam song request enqueue to periodic enqueue.