### PR TITLE
Dev/will/error starvation fix

### DIFF
--- a/control-board/src/tasks/control_task.rs
+++ b/control-board/src/tasks/control_task.rs
@@ -10,9 +10,7 @@ use ateam_controls::{Vector3f, Vector4f};
 
 use crate::create_error_telemetry_from_string;
 use ateam_lib_stm32::{
-    drivers::boot::stm32_interface,
-    idle_buffered_uart_spawn_tasks,
-    static_idle_buffered_uart,
+    drivers::boot::stm32_interface, idle_buffered_uart_spawn_tasks, static_idle_buffered_uart,
     util::RateLimiter,
 };
 use embassy_executor::{SendSpawner, Spawner};
@@ -189,10 +187,18 @@ impl<
             last_kicker_telemetry: Default::default(),
             ticks_since_basic_telem: 0,
             ticks_since_extended_telem: 0,
-            sched_lag_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
-            control_update_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
-            high_current_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
-            loop_exec_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
+            sched_lag_err_limiter: RateLimiter::new(Duration::from_millis(
+                ERROR_TELEM_RATE_LIMIT_MS,
+            )),
+            control_update_err_limiter: RateLimiter::new(Duration::from_millis(
+                ERROR_TELEM_RATE_LIMIT_MS,
+            )),
+            high_current_err_limiter: RateLimiter::new(Duration::from_millis(
+                ERROR_TELEM_RATE_LIMIT_MS,
+            )),
+            loop_exec_err_limiter: RateLimiter::new(Duration::from_millis(
+                ERROR_TELEM_RATE_LIMIT_MS,
+            )),
             motor_fl: motor_fl,
             motor_bl: motor_bl,
             motor_br: motor_br,
@@ -641,7 +647,9 @@ impl<
                     defmt::warn!("control loop is taking >{}us: {} us (it may be interrupted by higher priority tasks)", LOOP_EXECUTION_TIME_THRESHOLD_US, loop_execution_time_us);
                     self.telemetry_publisher
                         .publish_immediate(TelemetryPacket::ErrorTelemetry(
-                            create_error_telemetry_from_string("control loop execution time too high!"),
+                            create_error_telemetry_from_string(
+                                "control loop execution time too high!",
+                            ),
                         ));
                 }
             }

--- a/control-board/src/tasks/control_task.rs
+++ b/control-board/src/tasks/control_task.rs
@@ -10,7 +10,10 @@ use ateam_controls::{Vector3f, Vector4f};
 
 use crate::create_error_telemetry_from_string;
 use ateam_lib_stm32::{
-    drivers::boot::stm32_interface, idle_buffered_uart_spawn_tasks, static_idle_buffered_uart,
+    drivers::boot::stm32_interface,
+    idle_buffered_uart_spawn_tasks,
+    static_idle_buffered_uart,
+    util::RateLimiter,
 };
 use embassy_executor::{SendSpawner, Spawner};
 use embassy_stm32::{usart::Uart, Peri};
@@ -55,6 +58,10 @@ const TRACE_PRINT_FREQ: f32 = 10.0; // Hz, print trace info at this frequency
 const TIME_WITHOUT_PACKET_STOP: f32 = 0.5; // seconds, time without receiving a control packet before locking out motor commands
 
 const CONTROL_DT_US: u64 = (DEFAULT_CONTROL_DT * 1e6) as u64; // us
+
+// rate limit for error telemetry — prevents 1kHz error flood from starving radio
+// value is a diagnostic choice: UART at 5.25 Mbaud has negligible bandwidth constraint
+const ERROR_TELEM_RATE_LIMIT_MS: u64 = 50;
 const BASIC_TELEM_INTERVAL_TICKS: usize = (1.0 / BASIC_TELEM_FREQ * CONTROL_FREQ) as usize; // number of control loop ticks between basic telemetry sends
 const EXTENDED_TELEM_INTERVAL_TICKS: usize = (1.0 / EXTENDED_TELEM_FREQ * CONTROL_FREQ) as usize; // number of control loop ticks between extended telemetry sends
 const TRACE_PRINT_INTERVAL_TICKS: usize = (1.0 / TRACE_PRINT_FREQ * CONTROL_FREQ) as usize; // number of control loop ticks between trace prints
@@ -135,6 +142,11 @@ pub struct ControlTask<
     ticks_since_basic_telem: usize,
     ticks_since_extended_telem: usize,
 
+    sched_lag_err_limiter: RateLimiter,
+    control_update_err_limiter: RateLimiter,
+    high_current_err_limiter: RateLimiter,
+    loop_exec_err_limiter: RateLimiter,
+
     motor_fl: ControlWheelMotor,
     motor_bl: ControlWheelMotor,
     motor_br: ControlWheelMotor,
@@ -177,6 +189,10 @@ impl<
             last_kicker_telemetry: Default::default(),
             ticks_since_basic_telem: 0,
             ticks_since_extended_telem: 0,
+            sched_lag_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
+            control_update_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
+            high_current_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
+            loop_exec_err_limiter: RateLimiter::new(Duration::from_millis(ERROR_TELEM_RATE_LIMIT_MS)),
             motor_fl: motor_fl,
             motor_bl: motor_bl,
             motor_br: motor_br,
@@ -329,11 +345,13 @@ impl<
             let t_loop_start = Instant::now();
             let loop_invocation_dead_time = t_loop_start - last_loop_term_time;
             if loop_invocation_dead_time > Duration::from_micros(CONTROL_DT_US) {
-                defmt::warn!("control loop scheuling lagged. Expected <{:?}us between loop invocations, but got {:?}us", CONTROL_DT_US, loop_invocation_dead_time.as_micros());
-                self.telemetry_publisher
-                    .publish_immediate(TelemetryPacket::ErrorTelemetry(
-                        create_error_telemetry_from_string("control loop scheduling lagged"),
-                    ));
+                if self.sched_lag_err_limiter.is_allowed() {
+                    defmt::warn!("control loop scheuling lagged. Expected <{:?}us between loop invocations, but got {:?}us", CONTROL_DT_US, loop_invocation_dead_time.as_micros());
+                    self.telemetry_publisher
+                        .publish_immediate(TelemetryPacket::ErrorTelemetry(
+                            create_error_telemetry_from_string("control loop scheduling lagged"),
+                        ));
+                }
             }
 
             self.motor_fl.process_packets();
@@ -461,11 +479,13 @@ impl<
             ) {
                 Ok(_) => {}
                 Err(e) => {
-                    defmt::error!("control update error: {}", e);
                     self.shared_robot_state.set_controls_err(true);
-                    let err_telem = create_error_telemetry_from_string(e.as_str());
-                    self.telemetry_publisher
-                        .publish_immediate(TelemetryPacket::ErrorTelemetry(err_telem));
+                    if self.control_update_err_limiter.is_allowed() {
+                        defmt::error!("control update error: {}", e);
+                        let err_telem = create_error_telemetry_from_string(e.as_str());
+                        self.telemetry_publisher
+                            .publish_immediate(TelemetryPacket::ErrorTelemetry(err_telem));
+                    }
                 }
             }
             vision_update = false; // reset vision update flag after use
@@ -495,17 +515,19 @@ impl<
                 || wheel_ma.z.abs() > MAX_CURRENT_MA
                 || wheel_ma.w.abs() > MAX_CURRENT_MA
             {
-                defmt::warn!(
-                    "high wheel current command detected: {} {} {} {}",
-                    wheel_ma.x as i16,
-                    wheel_ma.y as i16,
-                    wheel_ma.z as i16,
-                    wheel_ma.w as i16
-                );
-                self.telemetry_publisher
-                    .publish_immediate(TelemetryPacket::ErrorTelemetry(
-                        create_error_telemetry_from_string("high wheel current rejected"),
-                    ));
+                if self.high_current_err_limiter.is_allowed() {
+                    defmt::warn!(
+                        "high wheel current command detected: {} {} {} {}",
+                        wheel_ma.x as i16,
+                        wheel_ma.y as i16,
+                        wheel_ma.z as i16,
+                        wheel_ma.w as i16
+                    );
+                    self.telemetry_publisher
+                        .publish_immediate(TelemetryPacket::ErrorTelemetry(
+                            create_error_telemetry_from_string("high wheel current rejected"),
+                        ));
+                }
                 wheel_ma = Vector4f::default();
             }
 
@@ -608,18 +630,20 @@ impl<
             // threshold for logging a warning about control loop execution time
             const LOOP_EXECUTION_TIME_THRESHOLD_US: u64 = 600; // 60% of execution frame
             if loop_execution_time_us > LOOP_EXECUTION_TIME_THRESHOLD_US {
-                defmt::warn!(
-                    "control loop trace: motor_pkt_proc: {} us, cmd_pkt_proc: {} us, control_update: {} us, publish: {} us",
-                    motor_packet_process_time.as_micros(),
-                    command_packet_process_time.as_micros(),
-                    control_update_time.as_micros(),
-                    channel_update_time.as_micros(),
-                );
-                defmt::warn!("control loop is taking >{}us: {} us (it may be interrupted by higher priority tasks)", LOOP_EXECUTION_TIME_THRESHOLD_US, loop_execution_time_us);
-                self.telemetry_publisher
-                    .publish_immediate(TelemetryPacket::ErrorTelemetry(
-                        create_error_telemetry_from_string("control loop execution time too high!"),
-                    ));
+                if self.loop_exec_err_limiter.is_allowed() {
+                    defmt::warn!(
+                        "control loop trace: motor_pkt_proc: {} us, cmd_pkt_proc: {} us, control_update: {} us, publish: {} us",
+                        motor_packet_process_time.as_micros(),
+                        command_packet_process_time.as_micros(),
+                        control_update_time.as_micros(),
+                        channel_update_time.as_micros(),
+                    );
+                    defmt::warn!("control loop is taking >{}us: {} us (it may be interrupted by higher priority tasks)", LOOP_EXECUTION_TIME_THRESHOLD_US, loop_execution_time_us);
+                    self.telemetry_publisher
+                        .publish_immediate(TelemetryPacket::ErrorTelemetry(
+                            create_error_telemetry_from_string("control loop execution time too high!"),
+                        ));
+                }
             }
             /////////////////////////////////////
 

--- a/control-board/src/tasks/radio_task.rs
+++ b/control-board/src/tasks/radio_task.rs
@@ -63,6 +63,7 @@ pub const RADIO_TX_BUF_DEPTH: usize = 6;
 pub const RADIO_MAX_RX_PACKET_SIZE: usize =
     ateam_common_packets::MAX_ROBOT_RX_PACKET_SIZE + EDM_PACKET_WIRE_OVERHEAD;
 pub const RADIO_RX_BUF_DEPTH: usize = 6;
+const RADIO_NON_ESSENTIAL_TELEM_CAP_PER_CYCLE: usize = RADIO_TX_BUF_DEPTH / 2;
 
 static_idle_buffered_uart!(RADIO, RADIO_MAX_RX_PACKET_SIZE, RADIO_RX_BUF_DEPTH, RADIO_MAX_TX_PACKET_SIZE, RADIO_TX_BUF_DEPTH, DEBUG_RADIO_UART_QUEUES, #[link_section = ".axisram.buffers"]);
 
@@ -578,7 +579,25 @@ impl<
             }
         }
 
+        // send basic telemetry at RADIO_BASIC_TELEM_INTERVAL_MS rate
+        // checked before draining queue so error/extended telem flood cannot starve keepalive
+        if Instant::now() - self.last_basic_telem_tx
+            >= Duration::from_millis(RADIO_BASIC_TELEM_INTERVAL_MS)
+        {
+            self.last_basic_telem_tx = Instant::now();
+            self.last_basic_telemetry.transmission_sequence_number = self.seq_number as u8;
+            self.seq_number = (self.seq_number + 1) & 0x00FF;
+
+            defmt::trace!("sending telem");
+            if let Err(e) = self.radio.send_telemetry(self.last_basic_telemetry) {
+                defmt::warn!("RadioTask - failed to send basic telem packet {:?}", e);
+            }
+        }
+
         // write outbound packets
+        // basic and parameter responses are essential — always drained
+        // extended and error are non-essential — capped at RADIO_NON_ESSENTIAL_TELEM_CAP_PER_CYCLE
+        let mut non_essential_sent = 0;
         loop {
             if let Some(telemetry) = self.telemetry_subscriber.try_next_message_pure() {
                 match telemetry {
@@ -586,14 +605,19 @@ impl<
                         self.last_basic_telemetry = basic;
                     }
                     TelemetryPacket::Extended(control) => {
-                        if self.shared_robot_state.get_radio_send_extended_telem() {
-                            defmt::trace!("RadioTask - sending extended telemetry");
-                            if let Err(e) = self.radio.send_control_debug_telemetry(control).await {
-                                defmt::warn!(
-                                    "RadioTask - failed to send control debug telemetry packet: {}",
-                                    e
-                                );
+                        if non_essential_sent < RADIO_NON_ESSENTIAL_TELEM_CAP_PER_CYCLE {
+                            if self.shared_robot_state.get_radio_send_extended_telem() {
+                                defmt::trace!("RadioTask - sending extended telemetry");
+                                if let Err(e) = self.radio.send_control_debug_telemetry(control).await {
+                                    defmt::warn!(
+                                        "RadioTask - failed to send control debug telemetry packet: {}",
+                                        e
+                                    );
+                                }
                             }
+                            non_essential_sent += 1;
+                        } else {
+                            defmt::warn!("RadioTask - dropping extended telemetry, non-essential cap reached");
                         }
                     }
                     TelemetryPacket::ParameterCommandResponse(pc_resp) => {
@@ -605,28 +629,19 @@ impl<
                         }
                     }
                     TelemetryPacket::ErrorTelemetry(error_packet) => {
-                        defmt::warn!("RadioTask - sending error telemetry packet");
-                        if let Err(e) = self.radio.send_error_telemetry(error_packet).await {
-                            defmt::warn!("RadioTask - failed to send error packet: {}", e);
+                        if non_essential_sent < RADIO_NON_ESSENTIAL_TELEM_CAP_PER_CYCLE {
+                            defmt::warn!("RadioTask - sending error telemetry packet");
+                            if let Err(e) = self.radio.send_error_telemetry(error_packet).await {
+                                defmt::warn!("RadioTask - failed to send error packet: {}", e);
+                            }
+                            non_essential_sent += 1;
+                        } else {
+                            defmt::warn!("RadioTask - dropping error telemetry, non-essential cap reached");
                         }
                     }
                 }
             } else {
                 break;
-            }
-        }
-
-        // send basic telemetry at RADIO_BASIC_TELEM_INTERVAL_MS rate
-        if Instant::now() - self.last_basic_telem_tx
-            >= Duration::from_millis(RADIO_BASIC_TELEM_INTERVAL_MS)
-        {
-            self.last_basic_telem_tx = Instant::now();
-            self.last_basic_telemetry.transmission_sequence_number = self.seq_number as u8;
-            self.seq_number = (self.seq_number + 1) & 0x00FF;
-
-            defmt::trace!("sending telem");
-            if let Err(e) = self.radio.send_telemetry(self.last_basic_telemetry) {
-                defmt::warn!("RadioTask - failed to send basic telem packet {:?}", e);
             }
         }
 

--- a/control-board/src/tasks/radio_task.rs
+++ b/control-board/src/tasks/radio_task.rs
@@ -608,7 +608,9 @@ impl<
                         if non_essential_sent < RADIO_NON_ESSENTIAL_TELEM_CAP_PER_CYCLE {
                             if self.shared_robot_state.get_radio_send_extended_telem() {
                                 defmt::trace!("RadioTask - sending extended telemetry");
-                                if let Err(e) = self.radio.send_control_debug_telemetry(control).await {
+                                if let Err(e) =
+                                    self.radio.send_control_debug_telemetry(control).await
+                                {
                                     defmt::warn!(
                                         "RadioTask - failed to send control debug telemetry packet: {}",
                                         e
@@ -636,7 +638,9 @@ impl<
                             }
                             non_essential_sent += 1;
                         } else {
-                            defmt::warn!("RadioTask - dropping error telemetry, non-essential cap reached");
+                            defmt::warn!(
+                                "RadioTask - dropping error telemetry, non-essential cap reached"
+                            );
                         }
                     }
                 }

--- a/lib-stm32/src/lib.rs
+++ b/lib-stm32/src/lib.rs
@@ -27,6 +27,7 @@ pub mod power;
 pub mod time;
 pub mod uart;
 pub mod units;
+pub mod util;
 
 // required for exported uart queue macros
 pub extern crate paste;

--- a/lib-stm32/src/util/mod.rs
+++ b/lib-stm32/src/util/mod.rs
@@ -1,0 +1,46 @@
+use embassy_time::{Duration, Instant};
+
+/// Time-based rate limiter gate. Tracks last-allowed timestamp; caller decides
+/// what action to take when `is_allowed` returns true.
+///
+/// Works for any call site — pubsub publishes, defmt prints, or anything else.
+///
+/// First call after construction always returns `true`.
+pub struct RateLimiter {
+    min_interval: Duration,
+    last_allowed: Instant,
+}
+
+impl RateLimiter {
+    pub fn new(min_interval: Duration) -> Self {
+        Self {
+            min_interval,
+            last_allowed: Instant::from_ticks(0),
+        }
+    }
+
+    /// Returns `true` and records current time if `min_interval` has elapsed
+    /// since last allowed call. Returns `false` otherwise.
+    pub fn is_allowed(&mut self) -> bool {
+        let now = Instant::now();
+        if now - self.last_allowed >= self.min_interval {
+            self.last_allowed = now;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Forces next `is_allowed` call to return `true` regardless of interval.
+    pub fn reset(&mut self) {
+        self.last_allowed = Instant::from_ticks(0);
+    }
+
+    pub fn min_interval(&self) -> Duration {
+        self.min_interval
+    }
+
+    pub fn set_min_interval(&mut self, interval: Duration) {
+        self.min_interval = interval;
+    }
+}


### PR DESCRIPTION
Addresses #141 

Adds layers of rate limiting for non essential telemetry in general in the radio task ensuring basic and parameter response have some rough priority ahead.

Adds rate limiter that should be usable everywhere. Long this might should be a marco lib or something with additional options.