### PR TITLE
initial impl of directionless ebrake

### DIFF
--- a/control-board/src/motion/active_brake.rs
+++ b/control-board/src/motion/active_brake.rs
@@ -1,0 +1,52 @@
+use crate::motion::params::controller_params::{
+    BRAKE_ANTI_JITTER_RADS, BRAKE_KP, BRAKE_MAX_CURRENT_A,
+};
+use crate::motion::pid::PidController;
+use ateam_controls::Vector4f;
+use nalgebra::SMatrix;
+
+/// Active braking controller for halt and emergency-stop states.
+///
+/// Drives each wheel to zero velocity using a P controller on raw encoder
+/// readings. KF-independent: no state estimator state is used, so this
+/// remains effective even under KF divergence.
+///
+/// Output is per-wheel current in Amperes (counter-direction to current velocity).
+/// The PidController provides anti-jitter near rest and hard output clamping.
+/// Ki and Kd are zero; add them here if proportional-only stopping is too slow.
+pub struct ActiveBrakeController {
+    pid: PidController<4>,
+}
+
+impl ActiveBrakeController {
+    pub fn new() -> Self {
+        // Gain rows: [Kp, Ki, Kd, Ki_err_min, Ki_err_max]
+        let gains = SMatrix::<f32, 4, 5>::from_row_slice(&[
+            BRAKE_KP, 0.0, 0.0, 0.0, 0.0,
+            BRAKE_KP, 0.0, 0.0, 0.0, 0.0,
+            BRAKE_KP, 0.0, 0.0, 0.0, 0.0,
+            BRAKE_KP, 0.0, 0.0, 0.0, 0.0,
+        ]);
+        let anti_jitter = Some(Vector4f::from_element(BRAKE_ANTI_JITTER_RADS));
+        let limits = Some((
+            Vector4f::from_element(-BRAKE_MAX_CURRENT_A),
+            Vector4f::from_element(BRAKE_MAX_CURRENT_A),
+        ));
+        let mut pid =
+            PidController::from_gains_matrix_with_anti_jitter(&gains, anti_jitter);
+        pid.set_output_limits(limits);
+        ActiveBrakeController { pid }
+    }
+
+    /// Returns per-wheel braking currents in Amperes.
+    ///
+    /// Setpoint is zero (stop); process variable is raw encoder velocity.
+    /// dt_s is the control loop period; only matters if Ki or Kd are non-zero.
+    pub fn compute(&mut self, wheel_vel_meas: Vector4f, dt_s: f32) -> Vector4f {
+        self.pid.calculate(&Vector4f::zeros(), &wheel_vel_meas, dt_s)
+    }
+
+    pub fn reset(&mut self) {
+        self.pid.reset();
+    }
+}

--- a/control-board/src/motion/mod.rs
+++ b/control-board/src/motion/mod.rs
@@ -1,3 +1,4 @@
+pub mod active_brake;
 pub mod body_controller;
 pub mod constant_gain_kalman_filter;
 pub mod control_context;

--- a/control-board/src/motion/params/controller_params.rs
+++ b/control-board/src/motion/params/controller_params.rs
@@ -104,6 +104,25 @@ const _: () = assert!(
 /// Applied after control policy output so feedback loops cannot overshoot.
 pub const STOP_STATE_LINEAR_SPEED_LIMIT: f32 = 1.25; // m/s (SSL rule limit: 1.5 m/s)
 
+/// Active brake controller parameters (halt and emergency-stop states).
+/// Uses raw encoder velocity only — no KF state — so it is robust against
+/// state estimator divergence.
+///
+/// Per-wheel braking current (A): I = clamp(-BRAKE_KP * ω, ±BRAKE_MAX_CURRENT_A)
+///
+/// Kp derivation: BRAKE_MAX_CURRENT_A / ω_expected_max, targeting current
+/// saturation at the top of the expected play-speed range. With 1.0 A and
+/// ~100 rad/s typical motor-shaft speed at play speed: Kp ≈ 0.01 A/(rad/s).
+///
+/// BRAKE_ANTI_JITTER_RADS: output is linearly scaled to zero below this
+/// threshold (via PidController anti-jitter) to avoid fighting encoder
+/// quantization noise near rest.
+///
+/// BRAKE_MAX_CURRENT_A must stay below MAX_CURRENT_MA / 1000 (2.5 A).
+pub const BRAKE_KP: f32 = 0.01; // A / (rad/s)
+pub const BRAKE_ANTI_JITTER_RADS: f32 = 5.0; // rad/s
+pub const BRAKE_MAX_CURRENT_A: f32 = 1.0; // A
+
 /// Encoder lag compensation operating mode.
 ///
 /// Intended progression: `Disabled` → `FeedforwardOnly` (validate model params)

--- a/control-board/src/tasks/control_task.rs
+++ b/control-board/src/tasks/control_task.rs
@@ -19,7 +19,11 @@ use embassy_time::{Duration, Instant, Ticker, Timer};
 
 use crate::{
     include_external_cpp_bin,
-    motion::{body_controller::BodyController, control_context::VisionGateEvent},
+    motion::{
+        active_brake::ActiveBrakeController,
+        body_controller::BodyController,
+        control_context::VisionGateEvent,
+    },
     motor::CurrentControlledMotor,
     parameter_interface::ParameterInterface,
     pins::*,
@@ -152,6 +156,8 @@ pub struct ControlTask<
     motor_bl: ControlWheelMotor,
     motor_br: ControlWheelMotor,
     motor_fr: ControlWheelMotor,
+
+    active_brake_controller: ActiveBrakeController,
 }
 
 impl<
@@ -215,6 +221,7 @@ impl<
             motor_bl: motor_bl,
             motor_br: motor_br,
             motor_fr: motor_fr,
+            active_brake_controller: ActiveBrakeController::new(),
         }
     }
 
@@ -556,18 +563,38 @@ impl<
             }
             vision_update = false; // reset vision update flag after use
 
-            let (wheel_current_cmd, wheel_vel_cmd) = if self.stop_wheels()
+            let in_hard_stop = self.stop_wheels()
                 || ticks_since_control_packet >= TICKS_WITHOUT_PACKET_STOP
                 || _cmd_mode == BodyControlMode::BCM_OFF
-                || robot_controller.wheels_disabled()
-                || self.last_command.game_state_in_halt() != 0
-                || self.last_command.emergency_stop() != 0
-            {
+                || robot_controller.wheels_disabled();
+
+            let in_active_brake = !in_hard_stop
+                && (self.last_command.game_state_in_halt() != 0
+                    || self.last_command.emergency_stop() != 0
+                    || _cmd_mode == BodyControlMode::BCM_ESTOP_BRAKE);
+
+            // wheel_current_cmd in Amperes; converted to mA below.
+            let (wheel_current_cmd, wheel_vel_cmd) = if in_hard_stop {
                 if ticks_since_trace_print > TRACE_PRINT_INTERVAL_TICKS {
                     defmt::warn!("control task - motor commands locked out");
                 }
+                self.active_brake_controller.reset();
                 (Vector4f::default(), Vector4f::default())
+            } else if in_active_brake {
+                // Force current-only mode every tick while braking so the motion
+                // type cannot lag behind game state changes between command packets.
+                self.motor_fl.set_motion_type(CcmMotionControlType::CCM_MCT_CURRENT);
+                self.motor_bl.set_motion_type(CcmMotionControlType::CCM_MCT_CURRENT);
+                self.motor_br.set_motion_type(CcmMotionControlType::CCM_MCT_CURRENT);
+                self.motor_fr.set_motion_type(CcmMotionControlType::CCM_MCT_CURRENT);
+                self.motor_fl.set_motion_enabled(true);
+                self.motor_bl.set_motion_enabled(true);
+                self.motor_br.set_motion_enabled(true);
+                self.motor_fr.set_motion_enabled(true);
+                let brake_a = self.active_brake_controller.compute(wheel_vel_meas, DEFAULT_CONTROL_DT);
+                (brake_a, Vector4f::default())
             } else {
+                self.active_brake_controller.reset();
                 (
                     robot_controller.get_wheel_currents(),
                     robot_controller.get_wheel_velocities(),


### PR DESCRIPTION
Implements non-direction-preserving active braking during halt and BCM_BRAKE_ESTOP for collision avoidance. 

Uses a P controller on each wheel using encoder vel only (no KF) to generate a counter ff current. Anti-jitter at 5rad/s. Max current for this counter force, 1A.